### PR TITLE
Don't use deprecated currentlyFocusedField

### DIFF
--- a/src/SpringScrollView.js
+++ b/src/SpringScrollView.js
@@ -498,8 +498,14 @@ export class SpringScrollView extends React.PureComponent<SpringScrollViewPropTy
   };
 
   _onTouchBegin = () => {
-    if (TextInputState.currentlyFocusedField())
-      TextInputState.blurTextInput(TextInputState.currentlyFocusedField());
+    const currentField = TextInputState.currentlyFocusedInput
+        ? TextInputState.currentlyFocusedInput()
+        : TextInputState.currentlyFocusedField();
+
+    if (currentField) {
+      TextInputState.blurTextInput(currentField);
+    }
+
     this.props.tapToHideKeyboard && Keyboard.dismiss();
     this.props.onTouchBegin && this.props.onTouchBegin();
   };


### PR DESCRIPTION
Merger of this PR from the original repository: https://github.com/bolan9999/react-native-spring-scrollview/pull/63